### PR TITLE
Add control flags for disabling upload/download/listing.

### DIFF
--- a/updog/templates/home.html
+++ b/updog/templates/home.html
@@ -28,6 +28,7 @@
         </div>
     </header>
 
+    {% if allow_upload %}
     <!-- ----- Upload Form ----- -->
     <div class="inputUploadP">
         <form method="post" action="/upload" enctype="multipart/form-data" class="uploadForm">
@@ -49,6 +50,7 @@
             </p>
         </form>
     </div>
+    {% endif %}
 
     {% if is_subdirectory %}
     <section class="backBtn_p">

--- a/updog/templates/home.html
+++ b/updog/templates/home.html
@@ -59,6 +59,7 @@
     </section>
     {% endif %}
 
+    {% if allow_listing %}
     <!-- Table -->
     <section class="table_p table-responsive">
         <table id="tableData" class="table table-hover compact">
@@ -82,7 +83,11 @@
                     {% endif %}
                 </td>
                 <td> <!-- Name -->
+                    {% if file.is_dir or allow_download %}
                     <a href="/{{ file.rel_path }}">{{ file.name }}{% if file.is_dir %}/{% endif %}</a>
+                    {% else %}
+                    {{ file.name }}
+                    {% endif %}
                 </td>
                 <td data-order="{{ file.size_sort }}"> <!-- File size -->
                     {{ file.size }}
@@ -100,6 +105,7 @@
             </tbody>
         </table>
     </section>
+    {% endif %}
 
     <footer>
         <p>


### PR DESCRIPTION
Add control options: `--no-listing` (Closes #20), `--no-upload` (Closes #3), and `--no-download`.

* With `--no-listing`, no files will be gathered and no table will be displayed. Requesting a non-file request other than to the base directory will redirect to the base directory.
* With `--no-download`, file links will be not be links. Attempting to visit the link manually will result in a 403 push-back.
* With `--no-upload`, the upload interface will not be displayed. Attempting to perform an upload manually without the GUI will result in a 405 push-back.
