### PR TITLE
Add support for existing SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Updog is a replacement for Python's `SimpleHTTPServer`. 
 It allows uploading and downloading via HTTP/S, 
-can set ad hoc SSL certificates and use HTTP basic auth.
+can set ad hoc or existing SSL certificates and use HTTP basic auth.
 
 <p align="center">
   <img src="https://sc0tfree.squarespace.com/s/updog-screenshot.png" alt="Updog screenshot"/>
@@ -31,6 +31,8 @@ Install using pip:
 | -p PORT, --port PORT                | Port to serve [Default=9090]                     |
 | --password PASSWORD                 | Use a password to access the page. (No username) |
 | --ssl                               | Enable transport encryption via SSL              |
+| --sslcert                           | Path to existing SSL certificate                 |
+| --sslkey                            | Path to existing SSL key (Passwords supported)   |
 | --version                           | Show version                                     |
 | -h, --help                          | Show help                                        |
 
@@ -59,6 +61,10 @@ enter the password in the password field.
 **Use an SSL connection:**
 
 `updog --ssl`
+
+Use a specific SSL certificate and SSL key (password protected keys supported):
+
+`updog --sslcert /path/to/certificate --sslkey /path/to/certificate_key`
 
 ## Thanks
 

--- a/updog/__main__.py
+++ b/updog/__main__.py
@@ -32,7 +32,9 @@ def parse_arguments():
     parser.add_argument('-p', '--port', type=int, default=9090,
                         help='Port to serve [Default=9090]')
     parser.add_argument('--password', type=str, default='', help='Use a password to access the page. (No username)')
-    parser.add_argument('--ssl', action='store_true', help='Use an encrypted connection')
+    parser.add_argument('--ssl', action='store_true', help='Use an encrypted connection (temporary SSL/TLS certificate)')
+    parser.add_argument('--sslcert', type=str, help='Use an encrypted connection (existing SSL/TLS certificate)')
+    parser.add_argument('--sslkey', type=str, help='Use an encrypted connection (existing SSL/TLS certificate key)')
     parser.add_argument('--version', action='version', version='%(prog)s v'+VERSION)
 
     args = parser.parse_args()
@@ -176,6 +178,8 @@ def main():
     ssl_context = None
     if args.ssl:
         ssl_context = 'adhoc'
+    elif args.sslcert and args.sslkey:
+        ssl_context = (args.sslcert, args.sslkey)
 
     run_simple("0.0.0.0", int(args.port), app, ssl_context=ssl_context)
 


### PR DESCRIPTION
As requested in #28, custom SSL certificate functionality is trivial with the [werkzeug.serving.run_simple](https://werkzeug.palletsprojects.com/en/1.0.x/serving/#werkzeug.serving.run_simple) function.

Tested by generating SSL certificates with the command:
`openssl req -x509 -days 365 -newkey rsa:2048 -keyout test-ssl.key -out test-ssl.crt` 