### PR TITLE
werkzeug version pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama
 flask
 flask_httpauth
-werkzeug
+werkzeug == 1.01
 pyopenssl


### PR DESCRIPTION
[Werkzeug version bump from 1.x to 2.x broke curl uploads](https://github.com/pallets/werkzeug/issues/2115); pinning version 1.01 fixes the problem.